### PR TITLE
Update minimatch dependency spec to ^3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "webpack": ">=3.0.0"
   },
   "dependencies": {
-    "minimatch": "3.0.4"
+    "minimatch": "^3.0.5"
   },
   "peerDependencies": {
     "html-webpack-plugin": ">=3.0.0",


### PR DESCRIPTION
Fixes audit

```
minimatch  <3.0.5
Severity: high
minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3
No fix available
node_modules/minimatch
  html-webpack-link-type-plugin  *
  Depends on vulnerable versions of minimatch
  node_modules/html-webpack-link-type-plugin
```